### PR TITLE
Update BeeGFS CSI provisioner version string

### DIFF
--- a/deploy/nomad/plugin.nomad
+++ b/deploy/nomad/plugin.nomad
@@ -35,7 +35,7 @@ job "beegfs-csi-plugin" {
         data        = <<EOH
 config:
   beegfsClientConf:
-    connUseRDMA: true
+    connUseRDMA: "true"
         EOH
         destination = "${NOMAD_TASK_DIR}/csi-beegfs-config.yaml"
       }
@@ -44,8 +44,8 @@ config:
       # https://github.com/NetApp/beegfs-csi-driver/blob/c65b53757afb1828d95521ec929e06a117f9a689/docs/deployment.md#connauth-configuration
       template {
         data        = <<EOH
-- connAuth: secret1
-  sysMgmtdHost: 1.1.1.1
+- connAuth: "secret1"
+  sysMgmtdHost: "1.1.1.1"
         EOH
         destination = "${NOMAD_SECRETS_DIR}/csi-beegfs-connauth.yaml"
       }

--- a/deploy/nomad/plugin.nomad
+++ b/deploy/nomad/plugin.nomad
@@ -64,7 +64,8 @@ config:
         }
 
         # Docker hub URL
-        image = "docker.repo.eng.netapp.com/netapp/beegfs-csi-driver:v1.2.0"
+        # image = "netapp/beegfs-csi-driver:v1.2.1"
+        image = "docker.repo.eng.netapp.com/netapp/beegfs-csi-driver:v1.2.1"
 
         # Arguments passed directly to the container, find in "var" in main.go.
         # https://github.com/NetApp/beegfs-csi-driver/blob/c65b53757afb1828d95521ec929e06a117f9a689/cmd/beegfs-csi-driver/main.go

--- a/deploy/nomad/plugin.nomad
+++ b/deploy/nomad/plugin.nomad
@@ -64,7 +64,7 @@ config:
         }
 
         # Docker hub URL
-        # image = "netapp/beegfs-csi-driver:v1.2.1"
+        # image = "docker.io/netapp/beegfs-csi-driver:v1.2.1"
         image = "docker.repo.eng.netapp.com/netapp/beegfs-csi-driver:v1.2.1"
 
         # Arguments passed directly to the container, find in "var" in main.go.


### PR DESCRIPTION
- v1.2.0-v1.2.1, to reflect current version.
- Also add a marked-out, public Docker Hub link for reference of non-NetApp users
- Surround Docker template values from plugin.nomad with double quotes

Note: this PR allows edits by maintainers, so feel free to change/improve it