### PR TITLE
Fix go version check script

### DIFF
--- a/hack/check-go-version.sh
+++ b/hack/check-go-version.sh
@@ -5,7 +5,7 @@
 
 # The GO_BUILD_VERSION is the official go version we are building the BeeGFS CSI driver with.
 GO_BUILD_VERSION="go1.22.0"
-INSTALLED_VERSION=$(go version | { read _ _ ver _; echo ${ver}; } )  || die "determining version of go failed"
+INSTALLED_VERSION=$(go version | { read _ _ ver _; echo ${ver}; } )  || { echo >&2 "ERROR: determining version of go failed"; exit 1; }
 
 if [ "$INSTALLED_VERSION" == "$GO_BUILD_VERSION" ]
 then


### PR DESCRIPTION
This was adapted long ago from another script that had a die function. All we really want to do is print an error and return a non-zero exit code.